### PR TITLE
fix: overridable _start_trap handler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,7 +483,7 @@ _vector_table:
     .option push
     .option norvc
     .rept 31
-    j default_start_trap
+    j _start_trap
     .endr
 
 "#


### PR DESCRIPTION
From the esp-hal linker scripts for the c2/c3, it looks like the intent was to allow downstream consumers to override the interrupt flow, e.g.

```
/* # Start trap function override
  By default uses the riscv crates default trap handler
  but by providing the `_start_trap` symbol external crates can override.
*/
PROVIDE(_start_trap = default_start_trap);
```

(via https://github.com/esp-rs/esp-hal/search?q=_start_trap )

But, prior to this change, the vector table points directly to the `default_start_trap` handler, denying the linker the opportunity to substitute a different target.