### PR TITLE
_vector_table: off by one, options missing pop?

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,18 +474,20 @@ abort:
 */
 
 .section .trap, "ax"
-.balign 0x100
 .global _vector_table
 .type _vector_table, @function
+
+.option push
+.balign 0x100
 .option norelax
+.option norvc
 
 _vector_table:
-    .option push
-    .option norvc
     j _start_trap
     .rept 31
     j _start_trap
     .endr
 
+.option pop
 "#
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,6 +482,7 @@ abort:
 _vector_table:
     .option push
     .option norvc
+    j _start_trap
     .rept 31
     j _start_trap
     .endr


### PR DESCRIPTION
In trying to build my own understanding of how the interrupt flow works, I've been spending a while staring at the different parts of the code. This PR is part "question I don't know how to answer" and part "I noticed this probably isn't right".

For the latter, I'm fairly confident that 6d5e3d4 fixes an actual bug: I didn't try too hard to come up with a test case that exposes the bad behavior, but inspecting the contents of memory (see below)  I saw

```
mtvec = 0x42000300 [_vector_table:??:??] ( _vector_table = 0x42000300 [_vector_table:??:??])
0x42000300 [_vector_table:??:??]: 0xe31ff06f
...
0x42000370 [_vector_table:??:??]: 0xdc1ff06f
0x42000374 [_vector_table:??:??]: 0xdbdff06f
0x42000378 [_vector_table:??:??]: 0xdb9ff06f
0x4200037c [_start_trap_rust_hal:??:??]: 0xc7867155
```

the instructions ending in 0x06f look like they decode to `jal x0, <immediate>` (AKA the "j" pseudo-instruction with an offset that's changing by 0x04 slot by slot as the relative jump gets further (or closer?) to go to the same place. The entry at `mtvec+0x7c` there, though, looks like it's two (compressed) instructions [0x7155](https://luplab.gitlab.io/rvcodecjs/#q=0x7155&abi=false&isa=RV32I) and [0xc786](https://luplab.gitlab.io/rvcodecjs/#q=0xc786&abi=false&isa=RV32I) that sure could start a function prologue, so I'm inclined to believe whoever is mapping that address to a symbol (`espflash`, maybe?) that it's the start of the rust-level trap function. 

For the question part: it seemed very strange to me that there would be a lonely `.option push` with no corresponding `.option pop` hanging out so far away from where most of the assembler options were being configured. Changing the order of things around didn't seem like it had much of an impact, probably because the vector table is at the end of the assembly block? But if there were more things added below it, they would all be subject to the `.balign 0x100` and `.option norelax`, even if `.option pop` were used to restore the previous value of the `rvc` setting, right? (Also, the `.section` name and "ax" flags, but those look fairly common to leave in situ). 

59a1c2b is my best guess at capturing the intent there, though I do wonder if it would be better to move the vector table into its own `global_asm!` entirely and/or delete the `.option push`. I'm also happy to put the rock back and revert that commit as well, whatever y'all think is best.

## inspecting memory

the snippet of a program I used to examine the _vector_table:

```rust
  extern "C" {
      #[link_name = "_vector_table"]
      fn vtable();
  }
  
  unsafe {
      let table = vtable as *const u32;
      println!(
          "mtvec = 0x{:x} ( _vector_table = 0x{:x})",
          mtvec::read().address(),
          table as usize
      );
  
      for i in 0..32 {
          let t = table.add(i);
          println!("0x{:x}: 0x{:x}", t as usize, *t);
      }
  }
```