### PR TITLE
Add external linkage to `start` entry point function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 // NOTE: Adapted from riscv-rt/src/lib.rs
 #![no_std]
 
-use core::arch::global_asm;
+use core::arch::{asm, global_asm};
 
 pub use riscv;
 use riscv::register::{
@@ -267,100 +267,92 @@ pub unsafe extern "Rust" fn default_setup_interrupts() {
     mtvec::write(_start_trap as usize, TrapMode::Direct);
 }
 
+
+/// Entry point of all programs (_start).
+///
+/// It initializes DWARF call frame information, the stack pointer, the
+/// frame pointer (needed for closures to work in start_rust) and the global
+/// pointer. Then it calls _start_rust.
+#[link_section = ".init"]
+#[export_name = "_start"]
+pub unsafe extern "Rust" fn start() -> ! {
+    asm!(
+        r#"
+        .option norelax
+        // Unsupported on ESP32-C2/C3
+        // csrw mie, 0
+        // csrw mip, 0
+
+        li  x1, 0
+        li  x2, 0
+        li  x3, 0
+        li  x4, 0
+        li  x5, 0
+        li  x6, 0
+        li  x7, 0
+        li  x8, 0
+        li  x9, 0
+        li  x10,0
+        li  x11,0
+        li  x12,0
+        li  x13,0
+        li  x14,0
+        li  x15,0
+        li  x16,0
+        li  x17,0
+        li  x18,0
+        li  x19,0
+        li  x20,0
+        li  x21,0
+        li  x22,0
+        li  x23,0
+        li  x24,0
+        li  x25,0
+        li  x26,0
+        li  x27,0
+        li  x28,0
+        li  x29,0
+        li  x30,0
+        li  x31,0
+
+        .option push
+        .option norelax
+        la gp, __global_pointer$
+        .option pop
+
+        // Check hart ID
+        csrr t2, mhartid
+        lui t0, %hi(_max_hart_id)
+        add t0, t0, %lo(_max_hart_id)
+        bgtu t2, t0, abort
+
+        // Allocate stacks
+        la sp, _stack_start
+        lui t0, %hi(_hart_stack_size)
+        add t0, t0, %lo(_hart_stack_size)
+
+        beqz t2, 2f  // Jump if single-hart
+        mv t1, t2
+        mv t3, t0
+    1:
+        add t0, t0, t3
+        addi t1, t1, -1
+        bnez t1, 1b
+    2:
+        sub sp, sp, t0
+
+        // Set frame pointer
+        add s0, sp, zero
+
+        jal zero, _start_rust
+        "#
+    );
+
+    unreachable!()
+}
+
 global_asm!(
     r#"
-
-/*
-    Entry point of all programs (_start).
-
-    It initializes DWARF call frame information, the stack pointer, the
-    frame pointer (needed for closures to work in start_rust) and the global
-    pointer. Then it calls _start_rust.
-*/
-
-.section .init, "ax"
-.global _start
-
-_start:
-    /* Jump to the absolute address defined by the linker script. */
-    lui ra, %hi(_abs_start)
-    jr %lo(_abs_start)(ra)
-
-// .section .text
-
-_abs_start:
-    .option norelax
-    .cfi_startproc
-    .cfi_undefined ra
-
-    // Unsupported on ESP32-C2/C3
-    // csrw mie, 0
-    // csrw mip, 0
-
-    li  x1, 0
-    li  x2, 0
-    li  x3, 0
-    li  x4, 0
-    li  x5, 0
-    li  x6, 0
-    li  x7, 0
-    li  x8, 0
-    li  x9, 0
-    li  x10,0
-    li  x11,0
-    li  x12,0
-    li  x13,0
-    li  x14,0
-    li  x15,0
-    li  x16,0
-    li  x17,0
-    li  x18,0
-    li  x19,0
-    li  x20,0
-    li  x21,0
-    li  x22,0
-    li  x23,0
-    li  x24,0
-    li  x25,0
-    li  x26,0
-    li  x27,0
-    li  x28,0
-    li  x29,0
-    li  x30,0
-    li  x31,0
-
-    .option push
-    .option norelax
-    la gp, __global_pointer$
-    .option pop
-
-    // Check hart ID
-    csrr t2, mhartid
-    lui t0, %hi(_max_hart_id)
-    add t0, t0, %lo(_max_hart_id)
-    bgtu t2, t0, abort
-
-    // Allocate stacks
-    la sp, _stack_start
-    lui t0, %hi(_hart_stack_size)
-    add t0, t0, %lo(_hart_stack_size)
-
-    beqz t2, 2f  // Jump if single-hart
-    mv t1, t2
-    mv t3, t0
-1:
-    add t0, t0, t3
-    addi t1, t1, -1
-    bnez t1, 1b
-2:
-    sub sp, sp, t0
-
-    // Set frame pointer
-    add s0, sp, zero
-
-    jal zero, _start_rust
-
-    .cfi_endproc
 
 /*
     Trap entry point (_start_trap)


### PR DESCRIPTION
This PR intends to extern the symbol for `start` entry point function, which is necessary for restoring the ESP32-C3 build for MCUboot bootloader (`feature = mcu-boot`).

Patches here are similar to those previously applied on https://github.com/esp-rs/esp-hal/pull/49 for **ESP32-C3** target.